### PR TITLE
점수 업데이트 시 NaN 값을 무시하도록 수정

### DIFF
--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -18,6 +18,7 @@ import parse from 'node-html-parser';
 import * as moment from 'moment';
 import { BatchUpdateGameDto } from 'src/dtos/batch-update-game.dto';
 import { teamNameToTeamId } from 'src/utils/teamid-mapper';
+import { instanceToPlain } from 'class-transformer';
 
 @Injectable()
 export class GameService {
@@ -81,7 +82,7 @@ export class GameService {
   ): Promise<void> {
     return await this.gameRepository.manager.transaction(async (manager) => {
       const game = await this.findOne(gameId);
-      if (currentStatus.awayScore || currentStatus.awayScore || isNaN(currentStatus.awayScore), isNaN(currentStatus.homeScore)) return;
+      // if (currentStatus.awayScore || currentStatus.awayScore || isNaN(currentStatus.awayScore), isNaN(currentStatus.homeScore)) return;
       game.home_team_score = currentStatus.homeScore;
       game.away_team_score = currentStatus.awayScore;
 
@@ -178,11 +179,15 @@ export class GameService {
           map((response) => extractStatus(response.data)), // 상태 추출
         ),
     }).pipe(
-      map(({ scores, status }) => ({
-        homeScore: scores.homeScore,
-        awayScore: scores.awayScore,
-        status: status.status,
-      })),
+      map(({ scores, status }) => {
+        const data = {
+          homeScore: scores.homeScore,
+          awayScore: scores.awayScore,
+          status: status.status,
+        };
+        this.logger.log(`Scrapped data for game ${gameId} -> homeScore: ${data.homeScore}, awayScore: ${data.awayScore}, status: ${data.status}`);
+        return data;
+      }),
     );
   }
 

--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -81,6 +81,7 @@ export class GameService {
   ): Promise<void> {
     return await this.gameRepository.manager.transaction(async (manager) => {
       const game = await this.findOne(gameId);
+      if (currentStatus.awayScore || currentStatus.awayScore || isNaN(currentStatus.awayScore), isNaN(currentStatus.homeScore)) return;
       game.home_team_score = currentStatus.homeScore;
       game.away_team_score = currentStatus.awayScore;
 

--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -82,7 +82,7 @@ export class GameService {
   ): Promise<void> {
     return await this.gameRepository.manager.transaction(async (manager) => {
       const game = await this.findOne(gameId);
-      // if (currentStatus.awayScore || currentStatus.awayScore || isNaN(currentStatus.awayScore), isNaN(currentStatus.homeScore)) return;
+      if (currentStatus.awayScore || currentStatus.awayScore || isNaN(currentStatus.awayScore), isNaN(currentStatus.homeScore)) return;
       game.home_team_score = currentStatus.homeScore;
       game.away_team_score = currentStatus.awayScore;
 


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->
스코어가 Number(null)로 NaN이 되어버리는 경우가 있습니다.
하지만 문자 중계 정보를 보면 또 제대로 되어 있고, 할 때마다 오류가 나는 경기가 달라집니다.
그래서 그냥 NaN 값이 들어오면 업데이트를 하지 않도록 했습니다!

원인이 무엇인지 알기 전까지는 그냥 이렇게 둘려고 합니다...

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 문자 중계 스크래핑 로직에 로그 추가
- [x] 점수 업데이트 시 NaN 값이 들어오면 무시하도록 땜빵 

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
