### PR TITLE
🐛 등록 경기의 status 변경 및 생성 시 status 반영

### DIFF
--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -54,6 +54,7 @@ export class GameService {
   async findOne(gameId: string): Promise<Game> {
     const game = await this.gameRepository.findOne({
       where: { id: gameId },
+      relations: { winning_team: true }
     });
     if (!game) {
       throw new NotFoundException(`Game with id ${gameId} not found.`);

--- a/src/types/registered-game-status.type.ts
+++ b/src/types/registered-game-status.type.ts
@@ -1,1 +1,1 @@
-export type TRegisteredGameStatus = '승' | '패' | '무' | '취';
+export type TRegisteredGameStatus = 'Win' | 'Lose' | 'Tie' | 'No game';


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

등록 경기의 status를 한글에서 영어로 변경
경기 등록 시 경기가 종료되었거나 취소되어있으면 status가 바로 업데이트되도록 변경

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
