### PR TITLE
🩹 등록 경기 수정 메소드를 Patch로 변경 및 이에 맞게 서비스 로직 수정

### DIFF
--- a/src/controllers/registered-game.controller.ts
+++ b/src/controllers/registered-game.controller.ts
@@ -7,9 +7,9 @@ import {
   Delete,
   HttpCode,
   HttpStatus,
-  Put,
   ParseIntPipe,
   Query,
+  Patch,
 } from '@nestjs/common';
 import {
   ApiCreatedResponse,
@@ -121,7 +121,7 @@ export class RegisteredGameController {
     return plainToInstance(RegisteredGameDto, registeredGame);
   }
 
-  @Put(':id')
+  @Patch(':id')
   @HttpCode(HttpStatus.OK)
   @JwtAuth('access')
   @ApiOperation({ summary: '유저가 등록한 해당하는 ID의 직관 경기 수정' })

--- a/src/services/registered-game.service.ts
+++ b/src/services/registered-game.service.ts
@@ -121,16 +121,6 @@ export class RegisteredGameService {
     updateRegisteredGameDto: UpdateRegisteredGameDto,
     user: User,
   ): Promise<void> {
-    const cheeringTeam = await this.teamService.findOne(
-      updateRegisteredGameDto.cheeringTeamId,
-    );
-
-    if (!cheeringTeam) {
-      throw new NotFoundException(
-        `Team with ID ${updateRegisteredGameDto.cheeringTeamId} not found`,
-      );
-    }
-
     const registeredGame = await this.registeredGameRepository.findOne({
       where: { id, user },
       relations: { cheering_team: true, game: true },
@@ -139,11 +129,28 @@ export class RegisteredGameService {
     if (!registeredGame) {
       throw new NotFoundException(`Registered game with ID ${id} not found`);
     }
-
-    registeredGame.cheering_team = cheeringTeam;
-    registeredGame.image = updateRegisteredGameDto.image;
-    registeredGame.seat = updateRegisteredGameDto.seat;
-    registeredGame.review = updateRegisteredGameDto.review;
+    
+    if (updateRegisteredGameDto.cheeringTeamId) {
+      const cheeringTeam = await this.teamService.findOne(
+        updateRegisteredGameDto.cheeringTeamId,
+      );
+  
+      if (!cheeringTeam) {
+        throw new NotFoundException(
+          `Team with ID ${updateRegisteredGameDto.cheeringTeamId} not found`,
+        );
+      }
+      registeredGame.cheering_team = cheeringTeam;
+    }
+    if (updateRegisteredGameDto.image) {
+      registeredGame.image = updateRegisteredGameDto.image;
+    }
+    if (updateRegisteredGameDto.seat) {
+      registeredGame.seat = updateRegisteredGameDto.seat;
+    }
+    if (updateRegisteredGameDto.review) {
+      registeredGame.review = updateRegisteredGameDto.review;
+    }
 
     await this.registeredGameRepository.save(registeredGame);
   }


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

등록 경기 update를 Patch로 바꾸고, 서비스 로직도 이에 맞게 일부 변경 식으로 수정했습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
