### PR TITLE
🩹 DTO 프론트 뷰에 맞게 변경

### DIFF
--- a/src/controllers/cheering-song.controller.ts
+++ b/src/controllers/cheering-song.controller.ts
@@ -23,9 +23,12 @@ import {
 import { plainToInstance } from 'class-transformer';
 import { JwtAuth } from 'src/decorator/jwt-token.decorator';
 import { UserDeco } from 'src/decorator/user.decorator';
-import { CheeringSongDto } from 'src/dtos/cheering-song.dto';
 import {
-  CursorPageDto,
+  CheeringSongDetailedDto,
+  CheeringSongDto,
+} from 'src/dtos/cheering-song.dto';
+import {
+  CursorPageCheeringSongDto,
   CursorPageOptionDto,
   CursorPageWithSearchOptionDto,
 } from 'src/dtos/cursor-page.dto';
@@ -48,88 +51,97 @@ export class CheeringSongController {
     summary: '검색한 응원가 목록 및 무한 스크롤 정보 반환',
   })
   @ApiOkResponse({
-    type: CursorPageDto<CheeringSongDto>,
+    type: CursorPageCheeringSongDto,
     example: {
       data: [
         {
           id: 271,
-          type: 'player',
           title: '고승민 응원가',
-          lyrics:
-            '롯~데의 고승민 안타 안타~\n롯~데의 고승민 안타 안타~~\n워어어 워어어 워어어어~\n워어어 워어어 워어어어~\n롯~데의~ 고승민 안타 안타~',
-          link: 'https://youtu.be/NstqdjNrJOw',
-          player: {
-            id: 169,
-            name: '고승민',
-            jersey_number: 65,
-            position: '2루수',
-            throws_bats: '우투좌타',
+          lyrics_preview: '롯~데의 고승민 안타 안타~',
+          team: {
+            id: 1,
+            name: '롯데',
           },
+          player: {
+            id: 134,
+            name: '고승민',
+            jerseyNumber: 65,
+          },
+          isLiked: false,
         },
         {
           id: 286,
-          type: 'team',
           title: '오늘도 승리한다',
-          lyrics:
-            '롯데 롯데 롯데\n워어 워어어어 워어어~\n롯데 롯데 롯데\n워어 워어어어 워어어어~\n롯데 롯데 롯데\n워어 워어어어 워어어~\n오늘도 승리한다 내일도 승리한다\n언제나 우리는 최강롯데~\n\n롯데 롯데 롯데\n워어 워어어어 워어어~\n롯데 롯데 롯데\n워어 워어어어 워어어어~\n롯데 롯데 롯데\n워어 워어어어 워어어~\n오늘도 승리한다 내일도 승리한다\n언제나 우리는 최강롯데~\n\n(간주)\n\n롯데 롯데 롯데\n워어 워어어어 워어어~\n롯데 롯데 롯데\n워어 워어어어 워어어어~\n롯데 롯데 롯데\n워어 워어어어 워어어~\n오늘도 승리한다 내일도 승리한다\n언제나 우리는 최강 롯데\n오늘도 승리한다 내일도 승리한다\n언제나 우리는 최강 롯데',
-          link: 'https://youtu.be/RPJdvochneY',
+          lyrics_preview: '롯데 롯데 롯데',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
           player: null,
+          isLiked: false,
         },
         {
           id: 293,
-          type: 'team',
           title: '마! 최강롯데 아이가',
-          lyrics:
-            '워어어 워어어어 필승 롯데\n워어어 워어어어 롯데 자이언츠\n워어어 워어어어 필승 롯데\n워어어 워어어어 롯데 자이언츠\n\n청춘을 태워\n승리로 그라운드를 뒤덮어\n가쁜 숨과 함성\n승리를 향한 열정\n\n거친 파도처럼\n세차게 공을 던져라\n갈매기보다 더 멀리\n담장 넘어로 날아라\n\n끝날때 까지 끝나지 않는다\n승리를 향한 집념을 보아라\n오늘도 터진다 마!마! 만루홈런\n\n워어어 워어어어 날려라 홈런\n워어어 워어어어 잡아라 삼진\n워어어 워어어어 필승 롯데\n워어어 워어어어 롯데 자이언츠\n\n마! 마! 힘차게 던져라\n마! 마! 힘차게 날려라\n마! 마! 우리가 우리가\n마! 마! 최강롯데 아이가!\n\n끝날때 까지 끝나지 않는다\n승리를 향한 집념을 보아라\n오늘도 터진다 마!마! 만루홈런\n\n워어어 워어어어 날려라 홈런\n워어어 워어어어 잡아라 삼진\n워어어 워어어어 필승 롯데\n워어어 워어어어 롯데 자이언츠\n\n워어어 워어어어 날려라 홈런\n워어어 워어어어 잡아라 삼진\n워어어 워어어어 필승 롯데\n워어어 워어어어 롯데 자이언츠',
-          link: 'https://youtu.be/7qhk9I2K6Jc',
+          lyrics_preview: '워어어 워어어어 필승 롯데',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
           player: null,
+          isLiked: false,
         },
         {
           id: 294,
-          type: 'team',
           title: '우리들의 빛나는 이 순간',
-          lyrics:
-            '워 워어어어 승리를 위해\n워어어어 큰 꿈을 향해\n워어어어 자 달려가자\n롯데 자이언츠~ (최!강!롯!데!)\n\n워 워어어어 워 워어어어\n워어어어 워 워어어어\n빛나리라 영원하라 롯데 자이언츠\n\n거친 파도 헤치며 날아오르는 그대여\n불타오른 거인의 뜨거운 심장으로\n멈추지 않고 달려가자\n나의 열정 꿈의 그라운드\n우리의 빛나는 이 순간을 기억하라\n\n워 워어어어 승리를 위해\n워어어어 큰 꿈을 향해\n워어어어 자 달려가자\n롯데 자이언츠 (최!강!롯!데!)\n\n워 워어어어 워 워어어어\n워어어어 워 워어어어\n빛나리라 영원하라 롯데 자이언츠',
-          link: 'https://youtu.be/K9xm7kaV6MA',
+          lyrics_preview: '워 워어어어 승리를 위해',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
           player: null,
+          isLiked: false,
         },
         {
           id: 307,
-          type: 'player',
           title: '박세혁 응원가',
-          lyrics:
-            '워어우워어어 NC 박세혁 워어우워어어 NC 박세혁\n워우워~ 안방마님 박세혁! 워우워~ 다이노스 박세혁!',
-          link: 'https://youtu.be/co08QIacru8',
-          player: {
-            id: 172,
-            name: '박세혁',
-            jersey_number: 10,
-            position: '포수',
-            throws_bats: '우투좌타',
+          lyrics_preview: '워어우워어어 NC 박세혁 워어우워어어 NC 박세혁',
+          team: {
+            id: 6,
+            name: 'NC',
           },
+          player: {
+            id: 137,
+            name: '박세혁',
+            jerseyNumber: 10,
+          },
+          isLiked: false,
         },
       ],
       meta: {
         take: 5,
         hasNextData: true,
-        cursor: 255,
+        cursor: 307,
       },
     },
   })
   async findBySearchWithInfiniteScroll(
     @Query() cursorPageWithSearchOptionDto: CursorPageWithSearchOptionDto,
-  ): Promise<CursorPageDto<CheeringSongDto>> {
+    @UserDeco() user: User,
+  ): Promise<CursorPageCheeringSongDto> {
     const { take, cursor, q } = cursorPageWithSearchOptionDto;
 
     const cheeringSongsWithCursorMeta =
       await this.cheeringSongService.findBySearchWithInfiniteScroll(
+        user,
         take,
         cursor,
         q,
       );
+    this.logger.debug(cheeringSongsWithCursorMeta);
 
     return plainToInstance(
-      CursorPageDto<CheeringSongDto>,
+      CursorPageCheeringSongDto,
       cheeringSongsWithCursorMeta,
     );
   }
@@ -142,13 +154,21 @@ export class CheeringSongController {
     description: '응원가 ID',
     example: 1,
   })
-  @ApiOkResponse({ type: CheeringSongDto })
+  @ApiOkResponse({ type: CheeringSongDetailedDto })
   @ApiNotFoundResponse()
   async findOne(
     @Param('id', ParseIntPipe) id: number,
-  ): Promise<CheeringSongDto> {
+    @UserDeco() user: User,
+  ): Promise<CheeringSongDetailedDto> {
     const cheeringSong = await this.cheeringSongService.findOne(id);
-    return plainToInstance(CheeringSongDto, cheeringSong);
+    const { isLiked } = await this.cheeringSongService.getCheeringSongIsLiked(
+      id,
+      user,
+    );
+    return plainToInstance(CheeringSongDetailedDto, {
+      ...cheeringSong,
+      isLiked,
+    });
   }
 
   @Get('teams/:teamId/types/:type')
@@ -178,78 +198,90 @@ export class CheeringSongController {
     },
   })
   @ApiOkResponse({
-    type: CursorPageDto<CheeringSongDto>,
+    type: CursorPageCheeringSongDto,
     example: {
       data: [
         {
           id: 273,
-          type: 'team',
           title: '부산 갈매기',
-          lyrics:
-            '빠바바빠바밤~\n빠바바빠바밤~\n빠바바빰빰빰~\n\n지금은 그 어디서 (최~강 롯데!)\n내 생각 잊었는가 (최~강 롯데!)\n꽃처럼 어여쁜 그 이름도\n고왔던 순이 순이야\n\n파도치는 부둣가에\n지나간 일들이 가슴에 남았는데\n\n부산 갈~매기~ 부산 갈~매기~\n너는 정녕 나를 잊었나\n\n빠바바빠바밤~\n빠바바빠바밤~\n빠바바빰빰빰~',
-          link: 'https://youtu.be/V0b9WKYZ59s',
+          lyrics_preview: '빠바바빠바밤~',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
           player: null,
+          isLiked: false,
         },
         {
           id: 274,
-          type: 'team',
           title: '돌아와요 부산항에',
-          lyrics:
-            '꽃 피는 동백섬에\n봄이 왔건만 (최~강롯데!)\n형제 떠난 부산항에(울산항에)\n갈매기만 슬피 우네 (최~강롯데!)\n\n오륙도 돌아가는 연락선마다\n목메어 불러봐도\n대답 없는 내 형제여\n\n돌아와요 부산항에(울산항에)\n그리운 내 형제여',
-          link: 'https://youtu.be/62jAw0CHZKA',
+          lyrics_preview: '꽃 피는 동백섬에',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
           player: null,
+          isLiked: false,
         },
         {
           id: 275,
-          type: 'team',
           title: '바다새',
-          lyrics:
-            '롯데! 롯데!\n최!강!롯!데!\n\n어두운 바닷가\n홀로 나는 새야 (새야)\n갈 곳을 잃었나\n하얀 바다새야 (우우우)\n힘없는 소리로\n홀로 우는 새야 (새야)\n내 짝을 잃었나\n하얀 바다새야 (우우우)\n\n롯데! 최!강!롯!데!\n\n모두 다 가고 없는데\n바다도 잠이 드는데\n새는 왜 날개짓하며\n저렇게 날아만 다닐까\n새야~ 해지고 어두운데\n새야~ 어디로 떠나갈까\n새야~ 날마저 기우는데\n새야~ 아픈 맘 어이 하나\n\n아아아아 새야\n아아아아 새야\n우우우 새야\n우우우 새야~ 새야~ 아~아~',
-          link: 'https://youtu.be/EkIgSyeqCLk',
+          lyrics_preview: '롯데! 롯데!',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
           player: null,
+          isLiked: false,
         },
         {
           id: 276,
-          type: 'team',
           title: '뱃노래',
-          lyrics:
-            '어기여차에애~ 어기여차에~ (워!)\n어기여차에애~ 어기여차에~ (워!)\n어기여차에애~ 어기여차에~ (워!)\n어기여차에애~ 어기여차에~ (워!)\n어기야 디여~차~ (어기여차~)\n어기야 디여~ 어기 여차! 승리로 가~ 잔다~\n어기야 디여~차~ (어기여차~)\n어기야 디여~ 어기 여차! 승리로 가~ 잔다~\n\n오~ 오오~ 오오~ 오오~ 오오오~\n오~ 오오오~ 오오~ 오오~ 오오~ 오오오~\n\n어기야 디여~차~ (어기여차~)\n어기야 디여~ 어기 여차!\n승리로 가~ 잔다~\n어기야 디여~차~ (어기여차~)\n어기야 디여~ 어기 여차!\n승리로 가~ 잔다~\n어기여차에애~ 어기여차에~ (워!)\n어기여차에애~ 어기여차에~ (워!)\n어기여차에애~ 어기여차에~ (워!)\n어기여차에애~ 어기여차에~ (워!)',
-          link: 'https://youtu.be/vd7zBbhRiJg',
+          lyrics_preview: '어기여차에애~ 어기여차에~ (워!)',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
           player: null,
+          isLiked: false,
         },
         {
           id: 277,
-          type: 'team',
           title: '승전가',
-          lyrics:
-            '롯데 롯데 롯데 롯~데~\n롯데 롯데 롯데 롯~데~\n롯데 롯데 롯데 롯~데~\n승리의 롯데! (화이팅!)\n\n롯데 롯데 롯데 롯~데~\n롯데 롯데 롯데 롯~데~\n롯데 롯데 롯데 롯~데~\n승리의 롯데! (화이팅!)\n\n승리의~ 노래를~\n랄라랄라랄라랄라랄라 롯데 자이언츠\n승리의~ 노래를~\n랄라랄라랄라랄라랄라 롯데 자이언츠\n\n롯데 롯데 롯데 롯~데~\n롯데 롯데 롯데 롯~데~\n롯데 롯데 롯데 롯~데~\n승리의 롯데! (화이팅!)\n\n롯데 롯데 롯데 롯~데~\n롯데 롯데 롯데 롯~데~\n롯데 롯데 롯데 롯~데~\n승리의 롯데! (화이팅!)',
-          link: 'https://youtu.be/NSR5kAxIEi0',
+          lyrics_preview: '롯데 롯데 롯데 롯~데~',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
           player: null,
+          isLiked: false,
         },
       ],
       meta: {
         take: 5,
         hasNextData: true,
-        cursor: 255,
+        cursor: 277,
       },
     },
   })
   async findByTeamAndNameWithInfiniteScroll(
+    @UserDeco() user: User,
     @Param('teamId', ParseIntPipe) teamId: number,
     @Param('type') type: TCheeringSongType,
     @Query() cursorPageOptionDto: CursorPageOptionDto,
-  ): Promise<CursorPageDto<CheeringSongDto>> {
+  ): Promise<CursorPageCheeringSongDto> {
     const { take, cursor } = cursorPageOptionDto;
 
     const cheeringSongsWithCursorMeta =
       await this.cheeringSongService.findByTeamIdAndTypeWithInfiniteScroll(
         teamId,
         type,
+        user,
         take,
         cursor,
       );
     return plainToInstance(
-      CursorPageDto<CheeringSongDto>,
+      CursorPageCheeringSongDto,
       cheeringSongsWithCursorMeta,
     );
   }

--- a/src/dtos/cheering-song.dto.ts
+++ b/src/dtos/cheering-song.dto.ts
@@ -1,6 +1,16 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Exclude, Expose } from 'class-transformer';
-import { IsNumber, IsString, IsUrl } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
+import { Exclude, Expose, Transform, Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsInstance,
+  IsNumber,
+  IsString,
+  IsUrl,
+  ValidateNested,
+} from 'class-validator';
+import { TeamDto } from './team.dto';
+import { PlayerDto } from './player.dto';
+import { CheeringSong } from 'src/entities/cheering-song.entity';
 
 @Exclude()
 export class CheeringSongDto {
@@ -20,6 +30,48 @@ export class CheeringSongDto {
   @Expose()
   title: string;
 
+  @ApiProperty({
+    description: '응원가 가사',
+    example: `찬란하게 빛날 최강두산 이유찬~ (이유찬!)`,
+  })
+  @IsString()
+  @Expose()
+  @Transform(({ obj }: { obj: CheeringSong }) => obj.lyrics.split('\n')[0])
+  lyrics_preview: string;
+
+  @ApiProperty({
+    description: '응원가 팀',
+    example: {
+      id: 2,
+      name: '두산',
+    },
+  })
+  @Type(() => TeamDto)
+  @ValidateNested()
+  @Expose()
+  team: TeamDto;
+
+  @ApiPropertyOptional({
+    description: '선수 응원가의 선수',
+  })
+  @Type(() => PlayerDto)
+  @ValidateNested()
+  @Expose()
+  player?: PlayerDto;
+
+  @ApiProperty({
+    description: '좋아요 여부',
+    example: false,
+  })
+  @IsBoolean()
+  @Expose()
+  isLiked: boolean;
+}
+
+@Exclude()
+export class CheeringSongDetailedDto extends OmitType(CheeringSongDto, [
+  'lyrics_preview',
+]) {
   @ApiProperty({
     description: '응원가 가사',
     example: `찬란하게 빛날 최강두산 이유찬~ (이유찬!)

--- a/src/dtos/cursor-page.dto.ts
+++ b/src/dtos/cursor-page.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Exclude, Expose } from 'class-transformer';
+import { Exclude, Expose, Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
@@ -7,7 +7,9 @@ import {
   IsNumber,
   IsOptional,
   IsString,
+  ValidateNested,
 } from 'class-validator';
+import { CheeringSongDto } from './cheering-song.dto';
 
 @Exclude()
 export class CursorPageMetaDto {
@@ -37,19 +39,23 @@ export class CursorPageMetaDto {
   cursor: number;
 }
 
+/** 제네릭으로 어떻게 할 수 있지 않을까??? 찾아봤지만 잘 안됨... */
 @Exclude()
-export class CursorPageDto<T> {
+export class CursorPageCheeringSongDto {
   @ApiProperty({
     description: '데이터의 배열 / 그 길이는 take를 넘지 않음',
   })
   @IsArray()
+  @Type(() => CheeringSongDto)
+  @ValidateNested()
   @Expose()
-  data: T[];
+  data: CheeringSongDto[];
 
   @ApiProperty({
     description: '페이지네이션 메타 정보',
   })
-  @IsInstance(CursorPageMetaDto)
+  @Type(() => CursorPageMetaDto)
+  @ValidateNested()
   @Expose()
   meta: CursorPageMetaDto;
 }

--- a/src/dtos/game.dto.ts
+++ b/src/dtos/game.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Exclude, Expose, Transform } from 'class-transformer';
-import { IsNumber, IsString } from 'class-validator';
+import { Exclude, Expose, Transform, Type } from 'class-transformer';
+import { IsNumber, IsString, ValidateNested } from 'class-validator';
 import { TeamDto } from './team.dto';
 import { StadiumDto } from './stadium.dto';
 
@@ -45,6 +45,8 @@ export class GameDto {
       name: 'LG',
     },
   })
+  @Type(() => TeamDto)
+  @ValidateNested()
   @Expose()
   @Transform(({ obj }) => obj.home_team)
   homeTeam: TeamDto;
@@ -56,6 +58,8 @@ export class GameDto {
       name: '삼성',
     },
   })
+  @Type(() => TeamDto)
+  @ValidateNested()
   @Expose()
   @Transform(({ obj }) => obj.away_team)
   awayTeam: TeamDto;
@@ -70,6 +74,8 @@ export class GameDto {
       address: 'no address',
     },
   })
+  @Type(() => StadiumDto)
+  @ValidateNested()
   @Expose()
   stadium: StadiumDto;
 
@@ -98,7 +104,10 @@ export class GameDto {
       name: '삼성',
     },
   })
+  @Type(() => TeamDto)
+  @ValidateNested()
   @Expose()
+  @Transform(({ obj }) => obj.winning_team)
   winningTeam?: TeamDto;
 }
 

--- a/src/dtos/player.dto.ts
+++ b/src/dtos/player.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose, Transform } from 'class-transformer';
+import { IsNumber, IsString } from 'class-validator';
+
+@Exclude()
+export class PlayerDto {
+  @ApiProperty({
+    description: '선수 ID',
+    example: 1,
+  })
+  @IsNumber()
+  @Expose()
+  id: number;
+
+  @ApiProperty({
+    description: '선수 이름',
+    example: 1,
+  })
+  @IsString()
+  @Expose()
+  name: number;
+
+  @ApiProperty({
+    description: '선수 등번호',
+    example: 7,
+  })
+  @IsNumber()
+  @Expose()
+  @Transform(({ obj }) => obj.jersey_number)
+  jerseyNumber: number;
+}

--- a/src/services/registered-game.service.ts
+++ b/src/services/registered-game.service.ts
@@ -129,12 +129,12 @@ export class RegisteredGameService {
     if (!registeredGame) {
       throw new NotFoundException(`Registered game with ID ${id} not found`);
     }
-    
+
     if (updateRegisteredGameDto.cheeringTeamId) {
       const cheeringTeam = await this.teamService.findOne(
         updateRegisteredGameDto.cheeringTeamId,
       );
-  
+
       if (!cheeringTeam) {
         throw new NotFoundException(
           `Team with ID ${updateRegisteredGameDto.cheeringTeamId} not found`,


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

경기, 응원가 API가 프론트 뷰에 알맞지 않은 정보를 보내주었던 것을 수정했습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 경기 API가 승리 팀을 보내지 않던 오류 수정
- [x] 응원가 API가 선수, 팀 정보 등 몇가지 정보를 누락하여 보내던 오류 수정

### 메모

이미 #81 에서 설명했지만, 제네릭이었던 것을 제네릭이 아니게 변경했습니다.

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
