### PR TITLE
✨ 좋아요한 응원가 목록을 무한 스크롤 정보와 함꼐 반환하는 API 추가

### DIFF
--- a/src/controllers/cheering-song.controller.ts
+++ b/src/controllers/cheering-song.controller.ts
@@ -138,7 +138,105 @@ export class CheeringSongController {
         cursor,
         q,
       );
-    this.logger.debug(cheeringSongsWithCursorMeta);
+
+    return plainToInstance(
+      CursorPageCheeringSongDto,
+      cheeringSongsWithCursorMeta,
+    );
+  }
+
+  @Get('liked')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '좋아요 한 응원가 목록 및 무한 스크롤 정보 반환',
+  })
+  @ApiOkResponse({
+    type: CursorPageCheeringSongDto,
+    example: {
+      data: [
+        {
+          id: 271,
+          title: '고승민 응원가',
+          lyrics_preview: '롯~데의 고승민 안타 안타~',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
+          player: {
+            id: 134,
+            name: '고승민',
+            jerseyNumber: 65,
+          },
+          isLiked: true,
+        },
+        {
+          id: 286,
+          title: '오늘도 승리한다',
+          lyrics_preview: '롯데 롯데 롯데',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
+          player: null,
+          isLiked: true,
+        },
+        {
+          id: 293,
+          title: '마! 최강롯데 아이가',
+          lyrics_preview: '워어어 워어어어 필승 롯데',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
+          player: null,
+          isLiked: true,
+        },
+        {
+          id: 294,
+          title: '우리들의 빛나는 이 순간',
+          lyrics_preview: '워 워어어어 승리를 위해',
+          team: {
+            id: 1,
+            name: '롯데',
+          },
+          player: null,
+          isLiked: true,
+        },
+        {
+          id: 307,
+          title: '박세혁 응원가',
+          lyrics_preview: '워어우워어어 NC 박세혁 워어우워어어 NC 박세혁',
+          team: {
+            id: 6,
+            name: 'NC',
+          },
+          player: {
+            id: 137,
+            name: '박세혁',
+            jerseyNumber: 10,
+          },
+          isLiked: true,
+        },
+      ],
+      meta: {
+        take: 5,
+        hasNextData: true,
+        cursor: 307,
+      },
+    },
+  })
+  async findByLikedWithInfiniteScroll(
+    @Query() cursorPageOptionDto: CursorPageOptionDto,
+    @UserDeco() user: User,
+  ): Promise<CursorPageCheeringSongDto> {
+    const { take, cursor } = cursorPageOptionDto;
+
+    const cheeringSongsWithCursorMeta =
+      await this.cheeringSongService.findByLikedWithInfiniteScroll(
+        user,
+        take,
+        cursor,
+      );
 
     return plainToInstance(
       CursorPageCheeringSongDto,


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

유저가 좋아요한 응원가 목록을 무한스크롤 정보와 함께 반환하는 API를 추가했습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
