### PR TITLE
✨ 좋아요한 응원가 엔드포인트를 타입에 따라 나눔

### DIFF
--- a/src/controllers/cheering-song.controller.ts
+++ b/src/controllers/cheering-song.controller.ts
@@ -142,10 +142,25 @@ export class CheeringSongController {
     );
   }
 
-  @Get('liked')
+  @Get('liked/types/:type')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: '좋아요 한 응원가 목록 및 무한 스크롤 정보 반환',
+  })
+  @ApiParam({
+    name: 'type',
+    type: String,
+    description: '응원가 타입',
+    examples: {
+      team: {
+        summary: '팀 공통 응원가',
+        value: 'team',
+      },
+      player: {
+        summary: '선수 응원가',
+        value: 'player',
+      },
+    },
   })
   @ApiOkResponse({
     type: CursorPageCheeringSongDto,
@@ -223,6 +238,7 @@ export class CheeringSongController {
     },
   })
   async findByLikedWithInfiniteScroll(
+    @Param('type') type: TCheeringSongType,
     @Query() cursorPageOptionDto: CursorPageOptionDto,
     @UserDeco() user: User,
   ): Promise<CursorPageCheeringSongDto> {
@@ -230,6 +246,7 @@ export class CheeringSongController {
 
     const cheeringSongsWithCursorMeta =
       await this.cheeringSongService.findByLikedWithInfiniteScroll(
+        type,
         user,
         take,
         cursor,

--- a/src/services/cheering-song.service.ts
+++ b/src/services/cheering-song.service.ts
@@ -288,6 +288,7 @@ export class CheeringSongService {
   }
 
   async findByLikedWithInfiniteScroll(
+    type: TCheeringSongType,
     user: User,
     take: number,
     cursor?: number,
@@ -300,6 +301,7 @@ export class CheeringSongService {
         'like_cheering_song.cheering_song_id = cheering_song.id',
       )
       .where('like_cheering_song.user_id = :user_id', { user_id: user.id })
+      .andWhere('cheering_song.type = :type', { type })
       .orderBy('cheering_song.id', 'ASC')
       .leftJoinAndSelect('cheering_song.player', 'player')
       .leftJoinAndSelect('cheering_song.team', 'team')


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

좋아요한 응원가 엔드 포인트를 타입에 따라 필터링 하도록 변경했습니다.

resolves #87 

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] type에 따라 필터링 하는 로직 추가

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

![image](https://github.com/user-attachments/assets/579565cd-71ca-43e9-ab80-f6a0df5f7f99)


<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
