### PR TITLE
🐛 dist에 refined-cheering-songs가 포함되지 않는 현상 수정

### DIFF
--- a/src/seeds/cheering-song.seed.ts
+++ b/src/seeds/cheering-song.seed.ts
@@ -1,0 +1,42 @@
+import * as samsungTeamSong from './refined-cheering-songs/samsung.team.song.json';
+import * as samsungPlayerSong from './refined-cheering-songs/samsung.player.song.json';
+import * as ssgTeamSong from './refined-cheering-songs/ssg.team.song.json';
+import * as ssgPlayerSong from './refined-cheering-songs/ssg.player.song.json';
+import * as ncTeamSong from './refined-cheering-songs/nc.team.song.json';
+import * as ncPlayerSong from './refined-cheering-songs/nc.player.song.json';
+import * as lotteTeamSong from './refined-cheering-songs/lotte.team.song.json';
+import * as lottePlayerSong from './refined-cheering-songs/lotte.player.song.json';
+import * as doosanPlayerSong from './refined-cheering-songs/doosan.player.song.json';
+import * as doosanTeamSong from './refined-cheering-songs/doosan.team.song.json';
+import * as hanhwaPlayerSong from './refined-cheering-songs/hanhwa.player.song.json';
+import * as hanhwaTeamSong from './refined-cheering-songs/hanhwa.team.song.json';
+import * as kiaPlayerSong from './refined-cheering-songs/kia.player.song.json';
+import * as kiaTeamSong from './refined-cheering-songs/kia.team.song.json';
+import * as kiwoomPlayerSong from './refined-cheering-songs/kiwoom.player.song.json';
+import * as kiwoomTeamSong from './refined-cheering-songs/kiwoom.team.song.json';
+import * as ktPlayerSong from './refined-cheering-songs/kt.player.song.json';
+import * as ktTeamSong from './refined-cheering-songs/kt.team.song.json';
+import * as lgPlayerSong from './refined-cheering-songs/lg.player.song.json';
+import * as lgTeamSong from './refined-cheering-songs/lg.team.song.json';
+import { ICheeringSongSeed } from 'src/types/seed.type';
+
+export const refinedCheeringSongs: ICheeringSongSeed[] = samsungTeamSong
+  .concat(samsungPlayerSong)
+  .concat(ssgTeamSong)
+  .concat(ssgPlayerSong)
+  .concat(ncTeamSong)
+  .concat(ncPlayerSong)
+  .concat(lotteTeamSong)
+  .concat(lottePlayerSong)
+  .concat(doosanPlayerSong)
+  .concat(doosanTeamSong)
+  .concat(hanhwaPlayerSong)
+  .concat(hanhwaTeamSong)
+  .concat(kiaPlayerSong)
+  .concat(kiaTeamSong)
+  .concat(kiwoomPlayerSong)
+  .concat(kiwoomTeamSong)
+  .concat(ktPlayerSong)
+  .concat(ktTeamSong)
+  .concat(lgPlayerSong)
+  .concat(lgTeamSong) as ICheeringSongSeed[];

--- a/src/services/cheering-song.service.ts
+++ b/src/services/cheering-song.service.ts
@@ -5,8 +5,6 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import * as path from 'path';
-import * as fs from 'fs';
 import { CheeringSong } from 'src/entities/cheering-song.entity';
 import { ICheeringSongSeed, TCheeringSongType } from 'src/types/seed.type';
 import { Brackets, FindOptionsWhere, MoreThan, Repository } from 'typeorm';
@@ -15,6 +13,7 @@ import { Player } from 'src/entities/player.entity';
 import { User } from 'src/entities/user.entity';
 import { LikeCheeringSong } from 'src/entities/like-cheering-song.entity';
 import { CursorPageCheeringSongDto } from 'src/dtos/cursor-page.dto';
+import { refinedCheeringSongs } from 'src/seeds/cheering-song.seed';
 
 @Injectable()
 export class CheeringSongService {
@@ -31,38 +30,7 @@ export class CheeringSongService {
   ) {}
 
   async seed() {
-    function readJSONFile(filePath: string): ICheeringSongSeed[] {
-      try {
-        const data = fs.readFileSync(filePath, 'utf-8');
-        return JSON.parse(data) as ICheeringSongSeed[];
-      } catch (error) {
-        console.error(`Error reading file ${filePath}:`, error);
-        return [];
-      }
-    }
-
-    function getCheeringSongData(): ICheeringSongSeed[] {
-      const dirPath = 'src/seeds/refined-cheering-songs';
-
-      let combinedData: ICheeringSongSeed[] = [];
-
-      try {
-        const files = fs.readdirSync(dirPath);
-        for (const file of files) {
-          if (path.extname(file) === '.json') {
-            const filePath = path.join(dirPath, file);
-            const fileData = readJSONFile(filePath);
-            combinedData = combinedData.concat(fileData);
-          }
-        }
-      } catch (error) {
-        console.error(`Error reading directory ${dirPath}:`, error);
-      }
-
-      return combinedData;
-    }
-
-    const cheeringSongSeeder = getCheeringSongData();
+    const cheeringSongSeeder = refinedCheeringSongs;
 
     await this.cheeringSongRepository.manager.transaction(async (manager) => {
       for (const seed of cheeringSongSeeder) {


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

refined-cheering-songs의 json 파일이 import 되는 곳을 만들어서
build 시 dist에 포함될 수 있도록 했습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 정제된 응원가 json 파일을 import하여 하나의 배열로 만드는 ts 파일 추가
- [x] fs로 파일을 불러오는 것 대신 이렇게 만들어진 ts 파일의 배열 변수를 seeds에서 이용하도록 변경

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
