### PR TITLE
♻️ 등록 경기의 이미지 주소 값을 nullable 하게 변경

### DIFF
--- a/src/dtos/registered-game.dto.ts
+++ b/src/dtos/registered-game.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, OmitType, PartialType } from '@nestjs/swagger';
 import { Exclude, Expose, Transform, Type } from 'class-transformer';
-import { IsNumber, IsString, ValidateNested } from 'class-validator';
+import { IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { TRegisteredGameStatus } from 'src/types/registered-game-status.type';
 import { TeamDto } from './team.dto';
 import { GameDto } from './game.dto';
@@ -16,12 +16,13 @@ export class RegisteredGameDto {
   id: number;
 
   @ApiProperty({
-    description: '',
+    description: 'S3에 등록되어 있는 직관 등록 경기 이미지로의 URL',
     example: 'http://example.com/url/to/image.jpg',
   })
   @IsString()
+  @IsOptional()
   @Expose()
-  image: string;
+  image?: string;
 
   @ApiProperty({
     description: '좌석 상세',

--- a/src/entities/registered-game.entity.ts
+++ b/src/entities/registered-game.entity.ts
@@ -19,8 +19,8 @@ export class RegisteredGame {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
-  image: string;
+  @Column({ nullable: true })
+  image?: string;
 
   @Column()
   seat: string;

--- a/src/services/registered-game.service.ts
+++ b/src/services/registered-game.service.ts
@@ -156,7 +156,7 @@ export class RegisteredGameService {
       throw new NotFoundException(`Registered game with ID ${id} not found`);
     }
 
-    if (updateRegisteredGameDto.cheeringTeamId) {
+    if (updateRegisteredGameDto.cheeringTeamId !== undefined) {
       const cheeringTeam = await this.teamService.findOne(
         updateRegisteredGameDto.cheeringTeamId,
       );
@@ -168,13 +168,13 @@ export class RegisteredGameService {
       }
       registeredGame.cheering_team = cheeringTeam;
     }
-    if (updateRegisteredGameDto.image) {
+    if (updateRegisteredGameDto.image !== undefined) {
       registeredGame.image = updateRegisteredGameDto.image;
     }
-    if (updateRegisteredGameDto.seat) {
+    if (updateRegisteredGameDto.seat !== undefined) {
       registeredGame.seat = updateRegisteredGameDto.seat;
     }
-    if (updateRegisteredGameDto.review) {
+    if (updateRegisteredGameDto.review !== undefined) {
       registeredGame.review = updateRegisteredGameDto.review;
     }
 


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

직관 경기 등록 시 이미지를 등록하지 않는 경우를 고려하여 이미지 주소 값에 null을 사용할 수 있도록 했습니다.

그에 따라, 업데이트 시의 로직도 조금 수정했습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->
## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
