### PR TITLE
✨ 다음 달 경기의 정보도 가져오도록 수정

### DIFF
--- a/src/dtos/registered-game.dto.ts
+++ b/src/dtos/registered-game.dto.ts
@@ -1,6 +1,11 @@
 import { ApiProperty, OmitType, PartialType } from '@nestjs/swagger';
 import { Exclude, Expose, Transform, Type } from 'class-transformer';
-import { IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import {
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 import { TRegisteredGameStatus } from 'src/types/registered-game-status.type';
 import { TeamDto } from './team.dto';
 import { GameDto } from './game.dto';

--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -49,7 +49,7 @@ export class GameService {
         away_team: true,
         winning_team: true,
         stadium: true,
-      }
+      },
     });
 
     return games;
@@ -58,7 +58,12 @@ export class GameService {
   async findOne(gameId: string): Promise<Game> {
     const game = await this.gameRepository.findOne({
       where: { id: gameId },
-      relations: { home_team: true, away_team: true, winning_team: true, stadium: true },
+      relations: {
+        home_team: true,
+        away_team: true,
+        winning_team: true,
+        stadium: true,
+      },
     });
     if (!game) {
       throw new NotFoundException(`Game with id ${gameId} not found.`);
@@ -208,18 +213,15 @@ export class GameService {
    * 크롤링 관련 로직:
    * Thanks to EvansKJ57
    */
-  getSchedules(): Observable<void> {
-    const date = new Date();
-    const curYear = date.getFullYear();
-
+  getSchedules(year: number, month: number): Observable<void> {
     return this.httpService
       .post<IRawScheduleList>(
         'https://www.koreabaseball.com/ws/Schedule.asmx/GetScheduleList',
         {
           leId: 1, // 1 => 1부 | 2 => 퓨쳐스 리그
           srIdList: [0 /*9, 6, 3, 4, 5, 7*/].join(','), // 0 => 프로팀 경기 | 1 => 시범경기 | 3,4,5,7 => 포스트 시즌 | 9 => 올스타전 | 6 => 모름
-          seasonId: curYear,
-          gameMonth: date.getMonth() + 1,
+          seasonId: year,
+          gameMonth: month,
           teamid: '', //LG => LG | 롯데 => LT | 두산 => OB | KIA => HT | 삼성 => SS | SSG => SK | NC => NC | 키움 => WO | KT => KT | 한화 => HH
         },
         {
@@ -235,7 +237,7 @@ export class GameService {
           );
           const refinedGameData: TGameSchedule = this.refineGamesData(
             convertRowsToArray,
-            curYear,
+            year,
           );
 
           return from(this.createMany(refinedGameData));

--- a/src/utils/get-next-month.util.ts
+++ b/src/utils/get-next-month.util.ts
@@ -1,0 +1,17 @@
+export const getNextMonth = (
+  year: number,
+  month: number,
+): { nextYear: number; nextMonth: number } => {
+  let nextMonth = month + 1;
+  let nextYear = year;
+
+  if (nextMonth > 12) {
+    nextMonth = 1;
+    nextYear += 1;
+  }
+
+  return {
+    nextYear,
+    nextMonth,
+  };
+};


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

월말에는 다음 달의 경기에 대한 정보가 필요한 바,
경기 데이터를 가져올 때 이번 달과 다음 달의 경기에 대한 정보를 모두 가져오도록 변경했습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
