### PR TITLE
🐛 경기 상태 업데이트 로직 수정

### DIFF
--- a/src/dtos/game.dto.ts
+++ b/src/dtos/game.dto.ts
@@ -32,7 +32,7 @@ export class GameDto {
 
   @ApiProperty({
     description: '경기 상태',
-    example: '경기 종료',
+    example: '경기종료',
   })
   @IsString()
   @Expose()

--- a/src/services/aws-s3.service.ts
+++ b/src/services/aws-s3.service.ts
@@ -29,7 +29,9 @@ export class AwsS3Service {
       ContentType: mimeType,
     });
     const result = await this.s3Client.send(command);
-    this.logger.log(`Image putting command sent. The result is:\n${instanceToPlain(result)}`);
+    this.logger.log(
+      `Image putting command sent. The result is:\n${instanceToPlain(result)}`,
+    );
     const fileUrl = `https://${bucketName}.s3.${region}.amazonaws.com/${uploadName}`;
     return fileUrl;
   }
@@ -44,7 +46,9 @@ export class AwsS3Service {
       ContentType: mimeType,
     });
     const result = await this.s3Client.send(command);
-    this.logger.log(`Image putting command sent. The result is:\n${instanceToPlain(result)}`);
+    this.logger.log(
+      `Image putting command sent. The result is:\n${instanceToPlain(result)}`,
+    );
     const fileUrl = `https://${bucketName}.s3.${region}.amazonaws.com/${uploadName}`;
     return fileUrl;
   }
@@ -59,7 +63,9 @@ export class AwsS3Service {
       Key: uploadName,
     });
     const result = await this.s3Client.send(command);
-    this.logger.log(`Image deleting command sent. The result is:\n${instanceToPlain(result)}`);
+    this.logger.log(
+      `Image deleting command sent. The result is:\n${instanceToPlain(result)}`,
+    );
   }
 
   private extractKeyFromUrl(url: string): string {

--- a/src/services/registered-game.service.ts
+++ b/src/services/registered-game.service.ts
@@ -219,7 +219,7 @@ export class RegisteredGameService {
   }
 
   private defineStatus(game: Game, registeredGame: RegisteredGame): void {
-    if (game.status === '경기 종료') {
+    if (game.status === '경기종료') {
       if (game.winning_team) {
         registeredGame.status =
           registeredGame.cheering_team.id === game.winning_team.id

--- a/src/types/crawling-game.type.ts
+++ b/src/types/crawling-game.type.ts
@@ -21,7 +21,7 @@ export type TStadium =
   | '사직'
   | '광주';
 
-export type TGameStatus = '경기 전' | '우천취소' | '경기 종료';
+export type TGameStatus = '경기전' | '경기종료';
 
 export type TGameSchedule = IGameData[];
 


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

경기 상태 업데이트 시의 로직을 수정하여 등록된 경기의 상태가 업데이트가 잘 되지 않는 것을 수정했습니다.

이에 따라 랭킹의 업데이트도 원활하게 될 것입니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
