### PR TITLE
타임존 설정 / 등록 경기의 상태 결정 시 winning_team을 참조하지 않도록 핫픽스

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,7 @@ services:
       - '80:3000'
     environment:
       - NODE_ENV=${NODE_ENV}
+      - TZ=${TZ}
       - DOMAIN=${DOMAIN}
       - DB_CONTAINER_NAME=${DB_CONTAINER_NAME}
       - DB_DATABASE_NAME=${DB_DATABASE_NAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - '3000:3000'
     environment:
       - NODE_ENV=${NODE_ENV}
+      - TZ=${TZ}
       - DOMAIN=${DOMAIN}
       - DB_CONTAINER_NAME=${DB_CONTAINER_NAME}
       - DB_DATABASE_NAME=${DB_DATABASE_NAME}

--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -15,7 +15,7 @@ import { Repository } from 'typeorm';
 import { TeamService } from './team.service';
 import { StadiumService } from './stadium.service';
 import parse from 'node-html-parser';
-import moment from 'moment-timezone';
+import * as moment from 'moment-timezone';
 import { BatchUpdateGameDto } from 'src/dtos/batch-update-game.dto';
 import { teamNameToTeamId } from 'src/utils/teamid-mapper';
 import { gameMonths } from 'src/seeds/game-months.seed';
@@ -145,7 +145,7 @@ export class GameService {
   }
 
   async getTodayGameIds(): Promise<string[]> {
-    const today = moment().tz('Asia/Seoul').startOf('day').format('YYYY-MM-DD');
+    const today = moment.tz('Asia/Seoul').startOf('day').format('YYYY-MM-DD');
 
     const todayGames = await this.gameRepository.find({
       where: {

--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -15,7 +15,7 @@ import { Repository } from 'typeorm';
 import { TeamService } from './team.service';
 import { StadiumService } from './stadium.service';
 import parse from 'node-html-parser';
-import * as moment from 'moment';
+import moment from 'moment-timezone';
 import { BatchUpdateGameDto } from 'src/dtos/batch-update-game.dto';
 import { teamNameToTeamId } from 'src/utils/teamid-mapper';
 import { gameMonths } from 'src/seeds/game-months.seed';
@@ -145,7 +145,7 @@ export class GameService {
   }
 
   async getTodayGameIds(): Promise<string[]> {
-    const today = moment().startOf('day').format('YYYY-MM-DD');
+    const today = moment().tz('Asia/Seoul').startOf('day').format('YYYY-MM-DD');
 
     const todayGames = await this.gameRepository.find({
       where: {

--- a/src/services/registered-game.service.ts
+++ b/src/services/registered-game.service.ts
@@ -220,9 +220,14 @@ export class RegisteredGameService {
 
   private defineStatus(game: Game, registeredGame: RegisteredGame): void {
     if (game.status === '경기종료') {
-      if (game.winning_team) {
+      if (game.away_team_score > game.home_team_score) {
         registeredGame.status =
-          registeredGame.cheering_team.id === game.winning_team.id
+          registeredGame.cheering_team.id === game.away_team.id
+            ? 'Win'
+            : 'Lose';
+      } else if (game.away_team_score > game.home_team_score) {
+        registeredGame.status =
+          registeredGame.cheering_team.id === game.home_team.id
             ? 'Win'
             : 'Lose';
       } else {


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

타임존을 설정하여 로그, 오늘의 경기 부분에서 이에 관련된 오류를 수정했습니다.

경기의 status가 경기 종료이고 **동점이 아닌데도 불구하고 winning_team이 null이거나 불러오지 못하는 오류가 있는 것 같아**
직관 등록 경기의 상태 결정 시 winning_team을 참조하지 않도록 수정했습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] NestJS에 타임존을 설정하여 로그 검색을 용이하게 함
- [x] 오늘의 경기를 받아올 때 타임존을 설정하여 어제 경기를 받아오지 않도록 함

- [x] 직관 등록 경기의 상태 결정 시 winning_team을 참조하지 않도록 함

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
