### PR TITLE
Fix/rank update

### DIFF
--- a/src/const/event.const.ts
+++ b/src/const/event.const.ts
@@ -1,5 +1,4 @@
 export enum EventName {
   REDIS_CONNECT = 'redis-connected',
   CACHED_USERS = 'user-warmed',
-  FINISHED_GAME = 'finished-game',
 }

--- a/src/services/rank.service.ts
+++ b/src/services/rank.service.ts
@@ -62,9 +62,12 @@ export class RankService {
       .getRawMany();
 
     for (const watched of todayRegisteredGame) {
+      const { team_id, user_id, date, status } = watched;
       await this.updateRankEntity({
-        ...watched,
-        thisYear: moment(watched.date).year(),
+        team_id,
+        user_id,
+        status,
+        year: moment(date).year(),
       });
       await this.updateRedisRankings(watched.user_id);
     }

--- a/src/services/rank.service.ts
+++ b/src/services/rank.service.ts
@@ -44,36 +44,6 @@ export class RankService {
     }
   }
 
-  /** @description 당일 직관 등록 경기 종료되면 바로 업데이트하기 */
-  @OnEvent(EventName.FINISHED_GAME)
-  async rankTodayUpdate(payload: { gameId: string }) {
-    const todayRegisteredGame = await this.registeredGameRepository
-      .createQueryBuilder('registered_game')
-      .innerJoin('registered_game.game', 'game')
-      .innerJoin('registered_game.cheering_team', 'team')
-      .innerJoin('registered_game.user', 'user')
-      .where('registered_game.game.id = :gameId', payload)
-      .select([
-        'registered_game.status AS status',
-        'team.id AS team_id',
-        'user.id AS user_id',
-        'game.date AS date',
-      ])
-      .getRawMany();
-
-    for (const watched of todayRegisteredGame) {
-      const { team_id, user_id, date, status } = watched;
-      await this.updateRankEntity({
-        team_id,
-        user_id,
-        status,
-        year: moment(date).year(),
-      });
-      await this.updateRedisRankings(watched.user_id);
-    }
-    this.logger.log(`${payload.gameId}로 등록된 직관 경기 랭킹 업데이트 완료`);
-  }
-
   /** @description rank entity에 저장 */
   async updateRankEntity(
     watchedGame: CreateRankDto,

--- a/src/services/registered-game.service.ts
+++ b/src/services/registered-game.service.ts
@@ -5,7 +5,13 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Between, EntityManager, Repository } from 'typeorm';
+import {
+  Between,
+  DataSource,
+  EntityManager,
+  QueryRunner,
+  Repository,
+} from 'typeorm';
 import {
   CreateRegisteredGameDto,
   UpdateRegisteredGameDto,
@@ -30,6 +36,7 @@ export class RegisteredGameService {
     private readonly teamService: TeamService,
     private readonly rankService: RankService,
     private readonly awsS3Service: AwsS3Service,
+    private readonly dataSource: DataSource,
   ) {}
 
   async create(
@@ -197,25 +204,57 @@ export class RegisteredGameService {
     }
   }
 
-  async batchBulkUpdateByGameId(gameId: string): Promise<void> {
-    const game = await this.gameService.findOne(gameId);
-    const registeredGames = await this.registeredGameRepository.find({
-      where: {
-        game,
-      },
-      relations: { cheering_team: true, game: true },
-    });
-    // const registeredGames = await this.registeredGameRepository.find();
+  async batchBulkUpdateByGameId(gameId: string) {
+    const qrRunner: QueryRunner = this.dataSource.createQueryRunner();
 
-    const promises = registeredGames.map(async (registeredGame) => {
-      const game = registeredGame.game;
+    await qrRunner.connect();
+    await qrRunner.startTransaction();
 
-      this.defineStatus(game, registeredGame);
+    try {
+      const game = await this.gameService.findOne(gameId);
+      const registeredGames = await this.registeredGameRepository.find({
+        where: {
+          game,
+          status: null,
+        },
+        relations: { cheering_team: true, game: true, user: true },
+      });
 
-      return this.registeredGameRepository.save(registeredGame);
-    });
+      for (const registeredGame of registeredGames) {
+        const team_id = registeredGame.cheering_team.id;
+        const user_id = registeredGame.user.id;
+        const game = registeredGame.game;
 
-    await Promise.all(promises);
+        this.defineStatus(game, registeredGame);
+
+        // 직관 경기 저장
+        const updatedGame = await qrRunner.manager
+          .getRepository(RegisteredGame)
+          .save(registeredGame);
+        const status = updatedGame.status;
+        // Rank 업데이트
+        await this.rankService.updateRankEntity(
+          {
+            status,
+            team_id,
+            user_id,
+            year: moment(game.date).year(),
+          },
+          qrRunner.manager,
+        );
+      }
+
+      await qrRunner.commitTransaction();
+      this.logger.log(`당일 경기:${gameId} 상태 데이트 후 트랜잭션 성공`);
+    } catch (error) {
+      await qrRunner.rollbackTransaction();
+      this.logger.error(
+        `당일 경기:${gameId} 상태 업데이트 후 트랜잭션 실패`,
+        error.stack,
+      );
+    } finally {
+      await qrRunner.release();
+    }
   }
 
   private defineStatus(game: Game, registeredGame: RegisteredGame): void {

--- a/src/services/registered-game.service.ts
+++ b/src/services/registered-game.service.ts
@@ -245,7 +245,7 @@ export class RegisteredGameService {
       }
 
       await qrRunner.commitTransaction();
-      this.logger.log(`당일 경기:${gameId} 상태 데이트 후 트랜잭션 성공`);
+      this.logger.log(`당일 경기:${gameId} 상태 업데이트 후 트랜잭션 성공`);
     } catch (error) {
       await qrRunner.rollbackTransaction();
       this.logger.error(

--- a/src/services/scheduling.service.ts
+++ b/src/services/scheduling.service.ts
@@ -7,7 +7,6 @@ import * as moment from 'moment-timezone';
 import { RegisteredGameService } from './registered-game.service';
 import { getNextMonth } from 'src/utils/get-next-month.util';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { EventName } from 'src/const/event.const';
 
 @Injectable()
 export class SchedulingService {
@@ -121,7 +120,6 @@ export class SchedulingService {
         async () => {
           // Cronjob 종료 시
           await this.registeredGameService.batchBulkUpdateByGameId(gameId);
-          this.eventEmitter.emit(EventName.FINISHED_GAME, { gameId });
         },
         true,
         'Asia/Seoul',


### PR DESCRIPTION
## 🤷‍♂️ Description

- 직관 경기 중 당일 경기 id로말고도 status 없는 조건 추가해서 랭킹 테이블이 여러번 업데이트 안되도록 변경
- 경기의 점수 업데이트 후 직관 경기 상태 업데이트할 때 트랜잭션으로 랭킹 테이블 같이 업데이트 하도록 변경
- 이벤트 이미터로 업데이트 하는 방식 제거
