### PR TITLE
🐛 스크래핑한 문자 중계 스코어 값이 number나 null이도록 변경 및 업데이트 로직 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "cookie-parser": "^1.4.6",
         "cron": "^3.1.7",
         "ioredis": "^5.4.1",
+        "is-number": "^7.0.0",
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.45",
         "node-html-parser": "^6.1.13",
@@ -7437,7 +7438,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "cookie-parser": "^1.4.6",
     "cron": "^3.1.7",
     "ioredis": "^5.4.1",
+    "is-number": "^7.0.0",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.45",
     "node-html-parser": "^6.1.13",

--- a/src/dtos/batch-update-game.dto.ts
+++ b/src/dtos/batch-update-game.dto.ts
@@ -2,10 +2,10 @@ import { IsIn, IsNumber } from 'class-validator';
 
 export class BatchUpdateGameDto {
   @IsNumber()
-  homeScore: number;
+  homeScore: number | null;
 
   @IsNumber()
-  awayScore: number;
+  awayScore: number | null;
 
   @IsIn(['경기전', '경기중', '경기종료'])
   status: string;

--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -19,6 +19,7 @@ import * as moment from 'moment-timezone';
 import { BatchUpdateGameDto } from 'src/dtos/batch-update-game.dto';
 import { teamNameToTeamId } from 'src/utils/teamid-mapper';
 import { gameMonths } from 'src/seeds/game-months.seed';
+import isNumber from 'is-number';
 
 @Injectable()
 export class GameService {
@@ -113,12 +114,7 @@ export class GameService {
   ): Promise<void> {
     return await this.gameRepository.manager.transaction(async (manager) => {
       const game = await this.findOne(gameId);
-      if (
-        currentStatus.awayScore ||
-        currentStatus.awayScore ||
-        isNaN(currentStatus.awayScore) ||
-        isNaN(currentStatus.homeScore)
-      )
+      if (currentStatus.awayScore === null || currentStatus.homeScore === null)
         return;
       game.home_team_score = currentStatus.homeScore;
       game.away_team_score = currentStatus.awayScore;
@@ -185,16 +181,18 @@ export class GameService {
       const homeScoreElement = root.querySelector('.teamHome em');
       const awayScoreElement = root.querySelector('.teamAway em');
 
-      const homeScore: number | null = homeScoreElement
-        ? parseInt(homeScoreElement.innerText)
-        : null;
-      const awayScore: number | null = awayScoreElement
-        ? parseInt(awayScoreElement.innerText)
-        : null;
+      const homeScore: number | null =
+        homeScoreElement && isNumber(homeScoreElement.innerText)
+          ? parseInt(homeScoreElement.innerText)
+          : null;
+      const awayScore: number | null =
+        awayScoreElement && isNumber(awayScoreElement.innerText)
+          ? parseInt(awayScoreElement.innerText)
+          : null;
 
       return {
-        homeScore,
-        awayScore,
+        homeScore: homeScore,
+        awayScore: awayScore,
       };
     };
 


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

스크래핑한 문자 중계 스코어 값이 number 이면 parseInt하고, 아니라면 null을 반환하도록 변경

그에 따라 스코어 업데이트 로직도 isNaN()을 삭제하여 간소화

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
