### PR TITLE
🚑 더블 헤더로 변경된 경기의 기존 레코드를 삭제하도록 변경

### DIFF
--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -387,6 +387,16 @@ export class GameService {
         }
 
         try {
+          if (!game.id.endsWith('0')) {
+            // 더블 헤더인 경우 변경 전 경기의 아이디로 등록된 레코드를 삭제해야함
+            // 삭제 하지 않아도 되는 경우에도 계속 이 스코프가 실행되므로 수정 필요
+            const preDoulbeHeaderGameId = `${game.id.slice(0, -1)}0`;
+            await manager.delete(Game, {
+              where: {
+                id: preDoulbeHeaderGameId,
+              },
+            });
+          }
           await manager.upsert(Game, game, ['id']);
         } catch (error) {
           console.error('게임 저장 중 오류 발생:', error);


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

더블 헤더로 변경된 경기의 기존 레코드를 삭제하여 중복을 방지했습니다.

하지만 삭제 후에도 더블 헤더 경기를 업데이트 할 때마다 해당 로직을 실행하도록 하는 문제가 있습니다.

향후 수정이 필요합니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
