### PR TITLE
🩹 등록 경기 응원 팀 수정 시 등록 경기의 상태 변경

### DIFF
--- a/src/services/registered-game.service.ts
+++ b/src/services/registered-game.service.ts
@@ -181,7 +181,15 @@ export class RegisteredGameService {
   ): Promise<void> {
     const registeredGame = await this.registeredGameRepository.findOne({
       where: { id, user },
-      relations: { cheering_team: true, game: true },
+      relations: {
+        cheering_team: true,
+        game: {
+          home_team: true,
+          away_team: true,
+          stadium: true,
+          winning_team: true,
+        },
+      },
     });
 
     if (!registeredGame) {
@@ -199,6 +207,10 @@ export class RegisteredGameService {
         );
       }
       registeredGame.cheering_team = cheeringTeam;
+      registeredGame.status = this.getStatus(
+        registeredGame.game,
+        registeredGame,
+      );
     }
     if (updateRegisteredGameDto.image !== undefined) {
       this.awsS3Service.deleteImage({


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

등록 경기의 응원 팀 수정 시 등록 경기의 상태 (승패여부) 를 변경합니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
