### PR TITLE
Feature/migration setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "class-validator": "^0.14.1",
         "cookie-parser": "^1.4.6",
         "cron": "^3.1.7",
+        "dotenv": "^16.4.5",
         "express-basic-auth": "^1.2.1",
         "ioredis": "^5.4.1",
         "moment": "^2.30.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,16 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "convert-song": "ts-node ./src/seeds/cheering-song-converter.ts"
+    "convert-song": "ts-node ./src/seeds/cheering-song-converter.ts",
+    "typeorm": "typeorm-ts-node-commonjs",
+    "migration:create": "npm run typeorm -- migration:create ./src/migration/files/schema-update",
+    "migration:generate": "npm run typeorm -- migration:generate ./src/migration/files/schema-update -d ./src/migration/datasource.ts",
+    "migration:show": "npm run typeorm -- migration:show -d ./dist/migration/datasource.js",
+    "migration:show:dev": "npm run typeorm -- migration:show -d ./src/migration/datasource.ts",
+    "migration:run": "npm run typeorm -- migration:run -d ./dist/migration/datasource.js",
+    "migration:run:dev": "npm run typeorm -- migration:run -d ./src/migration/datasource.ts",
+    "migration:revert": "npm run typeorm -- migration:revert -d ./dist/migration/datasource.js",
+    "migration:revert:dev": "npm run typeorm -- migration:revert -d ./src/migration/datasource.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.623.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "class-validator": "^0.14.1",
     "cookie-parser": "^1.4.6",
     "cron": "^3.1.7",
+    "dotenv": "^16.4.5",
     "express-basic-auth": "^1.2.1",
     "ioredis": "^5.4.1",
     "moment": "^2.30.1",

--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -4,8 +4,6 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 export const getDatabaseConfig = (
   configService: ConfigService,
 ): TypeOrmModuleOptions => {
-  const nodeEnv = configService.get<string>('NODE_ENV');
-
   return {
     type: 'postgres',
     host: configService.get<string>('DB_CONTAINER_NAME') || 'localhost',
@@ -13,7 +11,7 @@ export const getDatabaseConfig = (
     database: configService.get<string>('DB_DATABASE_NAME'),
     username: configService.get<string>('DB_USER'),
     password: configService.get<string>('DB_PASSWORD'),
-    entities: ['dist/**/entities/*.entity.{ts,js}'],
-    synchronize: nodeEnv !== 'production',
+    autoLoadEntities: true,
+    synchronize: false,
   };
 };

--- a/src/config/database.config.ts
+++ b/src/config/database.config.ts
@@ -11,7 +11,7 @@ export const getDatabaseConfig = (
     database: configService.get<string>('DB_DATABASE_NAME'),
     username: configService.get<string>('DB_USER'),
     password: configService.get<string>('DB_PASSWORD'),
-    autoLoadEntities: true,
+    entities: ['dist/**/entities/*.entity.{ts,js}'],
     synchronize: false,
   };
 };

--- a/src/migration/datasource.ts
+++ b/src/migration/datasource.ts
@@ -1,0 +1,24 @@
+import * as dotenv from 'dotenv';
+import { DataSource } from 'typeorm';
+
+dotenv.config();
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+export default new DataSource({
+  type: 'postgres',
+  host: process.env.DB_CONTAINER_NAME || 'localhost',
+  port: process.env.DB_TCP_PORT ? parseInt(process.env.DB_TCP_PORT) : 5432,
+  database: process.env.DB_DATABASE_NAME,
+  username: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  entities: [
+    isProduction ? 'dist/entities/*.entity.js' : 'src/entities/*.entity.ts',
+  ],
+  migrations: [
+    isProduction
+      ? 'dist/migration/files/**/*.js'
+      : 'src/migration/files/**/*.ts',
+  ],
+  migrationsTableName: 'migrations',
+});


### PR DESCRIPTION
## 🤷‍♂️ Description

- typeorm migration 기본 셋팅입니다.
- 개발 시에도 NODE_ENV는 development와 production 구분해야합니다.
- 마이그레이션 적용하는 명령어는 직접 컨테이너에 들어가서 명령어를 실행하도록 했습니다.(가끔 오류가 있는 경우 서버가 아예 시작이 안되는 경우가 있어서 자동은 보류 했습니다.)
- migarte:generate로 파일 생성 시 쿼리문 한번 확인해주세요. (예를 들면 단순히 컬럼 이름 변경하려고하는데 해당 명령어로 생성하면 컬럼을 드랍하고 새로 추가하는 방식으로 만들기 때문에 데이터 소실 위험성이 존재합니다.)
- 마이그레이션 적용할 때 개발할 때는 :dev붙여서 개발환경과 배포 환경을 분리하도록 했습니다.
