### PR TITLE
🩹 경기 저장 시 teamId 부분이 undefined가 되는 문제 일시적 해결

### DIFF
--- a/src/utils/teamid-mapper.ts
+++ b/src/utils/teamid-mapper.ts
@@ -10,4 +10,6 @@ export const teamNameToTeamId = {
   키움: 'WO',
   KT: 'KT',
   한화: 'HH',
+  나눔: 'WA',
+  드림: 'AE',
 };


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

현재 팀 이름이 나눔 / 드림인 경기에서 경기id의 팀id 부분이 undefined가 되는 문제가 있습니다.

아마 teamNameToTeamId 에 해당 필드가 없어서 생기는 문제인 것 같은데, 일단 하드 코딩으로 추가 했습니다.

**이 수정은 일단 일시적 해결책으로, 왜 seriesId가 9인 해당 이벤트 경기가 등록되게 되는지에 대한 원인을 파악하지는 못했습니다.**
**또한, 이로인해 team 테이블에 나눔 / 드림에 대한 레코드가 생성되어 응원가의 팀 선택 부분에 나눔 / 드림에 대한 메뉴가 추가되어 있습니다.**

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] teamNameToTeamId 객체에 나눔, 드림 필드 추가

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->
![image](https://github.com/user-attachments/assets/391ab0e6-adde-4c58-8d1e-2cddd7ac6eb7)

![image](https://github.com/user-attachments/assets/38a30882-fa97-4ba1-af49-e429b8a26362)


<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
