### PR TITLE
🐛 :typeorm-transactional bug fix

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -36,7 +36,8 @@ import { DataSource } from 'typeorm';
         if (!options) {
           throw new Error('Invalid options passed');
         }
-        return addTransactionalDataSource(new DataSource(options));
+        const dataSource = await new DataSource(options).initialize();
+        return addTransactionalDataSource(dataSource);
       },
       inject: [ConfigService],
     }),


### PR DESCRIPTION
- Error: DataSource with name "default" has already added.

## 🤷‍♂️ Description
 - Error: DataSource with name "default" has already added. 에러 수정을 위해서 코드 수정했습니다.
 - 참고 : https://github.com/Aliheym/typeorm-transactional/issues/53
 

