### PR TITLE
/teams가 정규팀 목록만 반환하도록 수정

### DIFF
--- a/src/controllers/team.controller.ts
+++ b/src/controllers/team.controller.ts
@@ -22,7 +22,7 @@ export class TeamController {
 
   @Get()
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: '모든 팀 혹은 해당 이름의 팀 정보 반환' })
+  @ApiOperation({ summary: '모든 정규 팀 혹은 해당 이름의 팀 정보 반환' })
   @ApiQuery({
     name: 'name',
     description: '팀 이름',

--- a/src/services/team.service.ts
+++ b/src/services/team.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Team } from 'src/entities/team.entity';
-import { Repository } from 'typeorm';
+import { Between, Repository } from 'typeorm';
 
 @Injectable()
 export class TeamService {
@@ -23,10 +23,17 @@ export class TeamService {
   async findAll(name?: string): Promise<Team[]> {
     if (name) {
       return await this.teamRepository.find({
-        where: { name },
+        where: {
+          id: Between(1, 10),
+          name,
+        },
       });
     } else {
-      return await this.teamRepository.find();
+      return await this.teamRepository.find({
+        where: {
+          id: Between(1, 10),
+        },
+      });
     }
   }
 


### PR DESCRIPTION
## 🤷‍♂️ Description

<!-- 구현 한 기능에 대해 작성해 주세요. -->

/teams가 id가 1-10인 정규 팀만을 반환하도록 변경했습니다.
나눔, 드림의 경우 id가 691,692입니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] id가 1-10인 정규 팀만을 반환하도록 변경
- [x] 이에 따라 docs의 설명 약간 변경 

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<!--BE의 경우 API 테스트 결과를 첨부해주세요-->

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

<!-- 이슈번호를 작성해주세요. -->
<!-- 여러 이슈를 입력시 comma(,) 단위로 구분해주세요 -->
<!-- ex) close #10, resolves #123 -->

<!-- ex) -->
<!-- closes #1 -->
