### PR TITLE
Fix/social login ios pwa support

### DIFF
--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -1,13 +1,17 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Injectable,
   InternalServerErrorException,
   Logger,
   UnauthorizedException,
 } from '@nestjs/common';
-import { User } from 'src/entities/user.entity';
-import { CreateLocalUserDto, LoginLocalUserDto } from 'src/dtos/user.dto';
+import {
+  CreateLocalUserDto,
+  LoginLocalUserDto,
+  UserWithSupportTeamDto,
+} from 'src/dtos/user.dto';
 import { CreateSocialAuthDto, CreateUserDto } from 'src/dtos/account.dto';
 import { TermService } from 'src/services/term.service';
 import { UserRedisService } from 'src/services/user-redis.service';
@@ -16,11 +20,7 @@ import { UserService } from 'src/services/user.service';
 import { Transactional, runOnTransactionCommit } from 'typeorm-transactional';
 import * as moment from 'moment';
 import { AuthService } from 'src/auth/auth.service';
-import {
-  SocialLinkStatus,
-  SocialLoginStatus,
-  SocialProvider,
-} from 'src/const/auth.const';
+import { SocialProvider } from 'src/const/auth.const';
 import { CachedTermList } from 'src/types/term.type';
 import { TermRedisService } from 'src/services/term-redis.service';
 @Injectable()
@@ -62,54 +62,58 @@ export class AccountService {
     sub: string,
     providerEmail: string,
     provider: SocialProvider,
-  ) {
-    let user: User | null;
-    let status: SocialLoginStatus = SocialLoginStatus.LOGIN;
-
+  ): Promise<{ user: UserWithSupportTeamDto; isNewUser: boolean }> {
+    let isNewUser = false;
     try {
       //해당 플랫폼으로 가입된 유저 조회
       const socialAuth = await this.authService.getSocialAuth(
         { sub, provider },
-        { user: true },
-        { user: { id: true, email: true } },
+        {},
+        { user_id: true },
       );
-      user = socialAuth?.user ?? null;
 
-      if (!user) {
-        const isExistUser = await this.userService.getUser(
-          { email: providerEmail },
-          {},
-          { id: true, email: true },
+      if (socialAuth) {
+        const user = await this.userService.getUserWithSupportTeamWithId(
+          socialAuth.user_id,
         );
-
-        // 동일 이메일이 이미 가입된 경우
-        if (isExistUser) {
-          status = SocialLoginStatus.DUPLICATE;
-          return { user: isExistUser, status };
-        }
-        //없는 경우
-        user = await this.createSocialUser(
-          { email: providerEmail },
-          { sub, provider, providerEmail, isPrimary: true },
-        );
-        status = SocialLoginStatus.SIGNUP;
-        runOnTransactionCommit(async () => {
-          try {
-            await this.userRedisService.saveUser(user);
-            await this.rankService.updateRedisRankings(user.id);
-          } catch (error) {
-            this.logger.warn(`유저 ${user.id} 캐싱 실패`, error.stack);
-          }
-        });
+        return { user, isNewUser };
       }
-      return { user, status };
+
+      const isExistUser = await this.userService.getUser(
+        { email: providerEmail },
+        {},
+        { id: true, email: true },
+      );
+
+      // 동일 이메일이 이미 가입된 경우
+      if (isExistUser) {
+        throw new ConflictException('이미 가입된 이메일입니다.');
+      }
+      //없는 경우
+      const createdUser = await this.createSocialUser(
+        { email: providerEmail },
+        { sub, provider, providerEmail, isPrimary: true },
+      );
+      const user = await this.userService.getUserWithSupportTeamWithId(
+        createdUser.id,
+      );
+      isNewUser = true;
+      runOnTransactionCommit(async () => {
+        try {
+          await this.userRedisService.saveUser(createdUser);
+          await this.rankService.updateRedisRankings(user.id);
+        } catch (error) {
+          this.logger.warn(`유저 ${user.id} 캐싱 실패`, error.stack);
+        }
+      });
+
+      return { user, isNewUser };
     } catch (error) {
       this.logger.error('Social login or signup failed');
-      return { user, status: SocialLoginStatus.FAIL };
+      throw new InternalServerErrorException('소셜 로그인 실패');
     }
   }
 
-  @Transactional()
   async createLocalUser(dto: CreateLocalUserDto): Promise<{ id: number }> {
     const { password, ...userData } = dto;
     const createdUser = await this.userService.saveUser(userData);
@@ -123,7 +127,6 @@ export class AccountService {
       }),
       this.agreeUserRequireTerm(createdUser.id),
     ]);
-    await this.agreeUserRequireTerm(createdUser.id);
 
     runOnTransactionCommit(async () => {
       try {
@@ -168,13 +171,12 @@ export class AccountService {
     });
 
     if (socialAuth) {
-      return { status: SocialLinkStatus.DUPLICATE };
+      throw new ConflictException('이미 연동했거나 가입하였습니다.');
     }
     try {
       await this.authService.createSocialAuth(data, userId);
-      return { status: SocialLinkStatus.SUCCESS };
     } catch (error) {
-      return { status: SocialLinkStatus.FAIL };
+      throw new InternalServerErrorException('계정 연동 실패');
     }
   }
 

--- a/src/account/account.service.ts
+++ b/src/account/account.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
+  HttpException,
   Injectable,
   InternalServerErrorException,
   Logger,
@@ -109,7 +110,9 @@ export class AccountService {
 
       return { user, isNewUser };
     } catch (error) {
-      this.logger.error('Social login or signup failed');
+      if (error instanceof HttpException) {
+        throw error;
+      }
       throw new InternalServerErrorException('소셜 로그인 실패');
     }
   }
@@ -176,6 +179,9 @@ export class AccountService {
     try {
       await this.authService.createSocialAuth(data, userId);
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
       throw new InternalServerErrorException('계정 연동 실패');
     }
   }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -209,7 +209,7 @@ export class AuthController {
   @ApiBadRequestResponse({ description: '유효하지 않은 provider인 경우' })
   @ApiConflictResponse({ description: '이미 해당 이메일로 가입한 경우' })
   @ApiInternalServerErrorResponse({ description: '소셜 로그인 처리 실패' })
-  @Post('/login/:provider/handle')
+  @Post('login/:provider/handle')
   @UseGuards(SocialPostGuard)
   async handleSocialLogin(
     @Param('provider', ProviderParamCheckPipe) provider: SocialProvider,
@@ -260,7 +260,7 @@ export class AuthController {
   })
   @ApiBadRequestResponse({ description: '유효하지 않은 provider인 경우' })
   @ApiInternalServerErrorResponse({ description: '소셜 연동 처리 실패' })
-  @Post('/link/:provider/handle')
+  @Post('link/:provider/handle')
   @HttpCode(HttpStatus.NO_CONTENT)
   @UseGuards(AccessTokenGuard, SocialPostGuard)
   async handleSocialLink(

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -16,6 +16,7 @@ import { LocalAuth } from 'src/entities/local-auth.entity';
 import { User } from 'src/entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppleOAuthStrategy } from './strategies/apple.strategy';
+import { SocialPostGuard } from './guard/social-post.guard';
 
 @Global()
 @Module({
@@ -31,6 +32,7 @@ import { AppleOAuthStrategy } from './strategies/apple.strategy';
     AccessTokenGuard,
     JwtStrategy,
     SocialAuthGuard,
+    SocialPostGuard,
     GoogleOAuthStrategy,
     KakaoOAuthStrategy,
     AppleOAuthStrategy,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -206,4 +206,16 @@ export class AuthService {
     const data = await this.authRedisService.getOAuthState(state);
     return data;
   }
+
+  async createUuidAndCachingCode(code: string): Promise<string | null> {
+    const uuid = uuidv7();
+    const result = await this.authRedisService.saveOAuthCode(code, uuid);
+
+    return result;
+  }
+
+  async getCodeByPid(uuid: string): Promise<string | null> {
+    const code = await this.authRedisService.getOAuthCode(uuid);
+    return code;
+  }
 }

--- a/src/auth/guard/social-post.guard.ts
+++ b/src/auth/guard/social-post.guard.ts
@@ -22,6 +22,7 @@ export class SocialPostGuard implements CanActivate {
 
     const provider = req.params.provider as SocialProvider;
     const pid = req.body?.pid;
+    const flowType = req.url.includes('link') ? 'link' : 'login';
 
     if (!provider || !Object.values(SocialProvider).includes(provider)) {
       throw new BadRequestException('유효하지 않은 provider');
@@ -34,7 +35,10 @@ export class SocialPostGuard implements CanActivate {
     const code = await this.authService.getCodeByPid(pid);
     if (!code) throw new UnauthorizedException('code 만료 또는 없음');
 
-    const socialUserInfo = await strategy.validateAndGetUserInfo(code, 'login');
+    const socialUserInfo = await strategy.validateAndGetUserInfo(
+      code,
+      flowType,
+    );
     req.socialUserInfo = socialUserInfo;
 
     return true;

--- a/src/auth/guard/social-post.guard.ts
+++ b/src/auth/guard/social-post.guard.ts
@@ -1,0 +1,42 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { OAuthStrategyManager } from '../strategies/OAuthStrategyManager';
+import { AuthService } from '../auth.service';
+import { OAUTH_STRATEGY_MANAGER, SocialProvider } from 'src/const/auth.const';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SocialPostGuard implements CanActivate {
+  constructor(
+    @Inject(OAUTH_STRATEGY_MANAGER)
+    private readonly oAuthStrategyManager: OAuthStrategyManager,
+    private readonly authService: AuthService,
+  ) {}
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+
+    const provider = req.params.provider as SocialProvider;
+    const pid = req.body?.pid;
+
+    if (!provider || !Object.values(SocialProvider).includes(provider)) {
+      throw new BadRequestException('유효하지 않은 provider');
+    }
+    if (!pid) {
+      throw new BadRequestException('pid 누락');
+    }
+
+    const strategy = this.oAuthStrategyManager.getStrategy(provider);
+    const code = await this.authService.getCodeByPid(pid);
+    if (!code) throw new UnauthorizedException('code 만료 또는 없음');
+
+    const socialUserInfo = await strategy.validateAndGetUserInfo(code, 'login');
+    req.socialUserInfo = socialUserInfo;
+
+    return true;
+  }
+}

--- a/src/const/auth.const.ts
+++ b/src/const/auth.const.ts
@@ -22,23 +22,11 @@ export const TFlowType = {
 
 export type TFlowType = (typeof TFlowType)[keyof typeof TFlowType];
 
-export const SocialLoginStatus = {
-  SIGNUP: 'SIGNUP',
-  LOGIN: 'LOGIN',
-  DUPLICATE: 'DUPLICATE',
-  FAIL: 'FAIL',
+export const OAuthStatus = {
+  SUCCESS: 'success',
+  FAIL: 'fail',
 } as const;
 
-export type SocialLoginStatus =
-  (typeof SocialLoginStatus)[keyof typeof SocialLoginStatus];
-
-export const SocialLinkStatus = {
-  SUCCESS: 'SUCCESS',
-  FAIL: 'FAIL',
-  DUPLICATE: 'DUPLICATE',
-} as const;
-
-export type SocialLinkStatus =
-  (typeof SocialLinkStatus)[keyof typeof SocialLinkStatus];
+export type OAuthStatus = (typeof OAuthStatus)[keyof typeof OAuthStatus];
 
 export const OAUTH_STRATEGY_MANAGER = Symbol('OAUTH_STRATEGY_MANAGER');

--- a/src/const/redis.const.ts
+++ b/src/const/redis.const.ts
@@ -5,8 +5,10 @@ export const RedisKeys = {
   EMAIL_CODE: 'code',
   /** @description [Namespace 필수] 전체 : total, 팀 : teamId */
   RANKING: 'rank',
-  /** @description [Namespace 필수] uuid - 임시 코드 캐싱용*/
+  /** @description [Namespace 필수] uuid - 임시 스테이트 캐싱용*/
   OAUTH_STATE: 'oauthState',
+  /**@description [Namespace 필수] - 소셜 플랫폼에서 받은 코드 캐싱 */
+  OAUTH_CODE: 'oauthCode',
   /** @description [Namespace 없음] 필수 선택 전체 약관 리스트 캐싱용*/
   Term: 'term',
   /** @description [Namespace 필수] 유저 약관 정보 캐싱용*/

--- a/src/dtos/auth.dto.ts
+++ b/src/dtos/auth.dto.ts
@@ -8,3 +8,8 @@ export class AccessTokenResDto {
   @ApiProperty()
   teamName: string;
 }
+
+export class PidReqDto {
+  @ApiProperty({ example: '0195cd96-253c-7ffc-bfb4-88dcea935daa' })
+  pid: string;
+}

--- a/src/dtos/user.dto.ts
+++ b/src/dtos/user.dto.ts
@@ -227,3 +227,13 @@ export class TermAgreeDto {
   @IsString({ each: true })
   termIds: string[];
 }
+
+export class UserWithSupportTeamDto {
+  id: number;
+  email: string;
+  nickname: string;
+  support_team: {
+    id: number;
+    name: string;
+  };
+}

--- a/src/pipe/social-flow-param-check.pipe.ts
+++ b/src/pipe/social-flow-param-check.pipe.ts
@@ -1,0 +1,12 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+import { SocialFlowType } from 'src/types/auth.type';
+
+@Injectable()
+export class SocialFlowParamPipe implements PipeTransform {
+  transform(value: SocialFlowType) {
+    if (value !== 'link' && value !== 'login') {
+      throw new BadRequestException('유효하지 않은 요청 url');
+    }
+    return value;
+  }
+}

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -20,6 +20,7 @@ import { UserRedisService } from './user-redis.service';
 import { runOnTransactionCommit, Transactional } from 'typeorm-transactional';
 import { TermService } from './term.service';
 import { CreateUserDto } from 'src/dtos/account.dto';
+import { UserWithSupportTeamDto } from 'src/dtos/user.dto';
 
 @Injectable()
 export class UserService {
@@ -104,6 +105,22 @@ export class UserService {
       select,
     });
     return user;
+  }
+
+  async getUserWithSupportTeamWithId(
+    userId: number,
+  ): Promise<UserWithSupportTeamDto> {
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+      relations: { support_team: true },
+      select: {
+        id: true,
+        email: true,
+        nickname: true,
+        support_team: { id: true, name: true },
+      },
+    });
+    return user as UserWithSupportTeamDto;
   }
 
   async changeUserProfile(

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -6,6 +6,8 @@ export interface IJwtPayload {
   type: 'ac' | 'rf';
 }
 
+export type SocialFlowType = 'login' | 'link';
+
 export interface IOAuthStrategy {
   provider: SocialProvider;
   getCodeAuthUrl(flowType: TFlowType, state: string): string;


### PR DESCRIPTION
## 🤷‍♂️ Description

- ios 앱 환경에서  소셜 로그인 / 연동이 되도록 로직 흐름 수정

### 변경 전
1. 프론트에서 `window.location.href`로 백엔드 리다이렉트
2. 백엔드에서 소셜 로그인창으로 리다이렉트
3. 유저가 소셜 플랫폼 로그인 진행
4. 소셜 플랫폼에서 백엔드로 리다이렉트
5. 백엔드가 유저 정보 획득 및 로그인/회원가입/에러/중복 처리
6. 백엔드가 다시 프론트로 리다이렉트 (JSON 없음) -> 쿼리파람에 status로 상태전달
7. 프론트는 쿼리파라미터로 분기 처리 및 액세스토큰 요청

### 변경 후

1. 프론트에서 `window.open`으로 백엔드 요청 (새 탭 열기)
    - 이벤트 리스너 등록 필요
2. 백엔드는 소셜 로그인 페이지로 리다이렉트
3. 유저가 소셜 플랫폼 로그인 진행
4. 소셜 플랫폼에서 다시 백엔드로 리다이렉트
5. 백엔드가 임의의 UUID 생성 후, 소셜 로그인에서 받은 코드 임시 캐싱
6. UUID 및 flowType(login/link)을 붙여 프론트 콜백 페이지로 리다이렉트
    - 예시 URL: `{BASE_FRONT_URL}/oauth/callback?status=success&pid={randomUUID}&flowtype=login`
7. 프론트 콜백 페이지에서 쿼리 파라미터(pid, flowtype, status)를 확인 후, 기존 탭으로 postMessage 전송
8. 기존 탭의 이벤트 리스너에서 메시지(pid, flowtype)를 받아서 body에 pid 넣어 API 호출
    - API 예시: `[POST] {BACK_END_URL}/auth/{flowtype}/{provider}/handle`
9. 백엔드에서 API 요청 수신 후 캐싱된 코드 확인, 유저 정보 획득 및 로그인/회원가입/에러 처리
10. JSON 형태로 프론트에 결과 응답
    - 응답 데이터 기준으로 프론트에서 회원가입, 로그인, 중복 처리, 실패 처리 등 진행
