### PR TITLE
🚑 : 이메일 중복확인에서 로직 에러 수정

### DIFF
--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -67,7 +67,11 @@ export class UserService {
         select: { id: true, email: true, local_auth: { user_id: true } },
       });
       const isExist = user ? true : false;
-      const initialSignUpType = !user.local_auth ? 'social' : 'local';
+      let initialSignUpType: 'local' | 'social' | null = null;
+
+      if (isExist) {
+        initialSignUpType = user.local_auth ? 'local' : 'social';
+      }
 
       return { isExist, initialSignUpType };
     } catch (error) {


### PR DESCRIPTION
## 🤷‍♂️ Description

- initialSignUpType 값 생성 시 user없는지 확인하지 않고 local_auth 값을 접근할 때 런타임 에러 발생