### PR TITLE
🐛 : spam 처리되는 문제 수정 시도

### DIFF
--- a/src/core/mail/mail.service.ts
+++ b/src/core/mail/mail.service.ts
@@ -18,6 +18,7 @@ export class MailService {
         from: `승리요정 <${fromAddress}>`,
         to: email,
         subject: '승리요정 인증 코드 번호입니다.',
+        text: `안녕하세요. 요청하신 인증 코드는 ${code}입니다. 3분간 유효합니다.`,
         html: this.generateHtmlTemplate(code),
       });
       return true;


### PR DESCRIPTION
## 🤷‍♂️ Description
- 이메일 내용에 text도 같은 내용으로 추가 
- 참고 : https://stackoverflow.com/questions/40608635/email-send-through-nodemailer-goes-into-spam-for-gmail