### PR TITLE
fix/prevent duplicate cron jobs by deleting after stop()

### DIFF
--- a/src/modules/game/game.service.ts
+++ b/src/modules/game/game.service.ts
@@ -68,7 +68,6 @@ export class GameService {
     return games;
   }
 
-
   /** 추후 레디스에 캐싱하는 방식으로 리팩토링 필요 */
   async updateStatusRepeatedly(
     gameId: string,
@@ -108,7 +107,6 @@ export class GameService {
       await manager.update(Game, { id: gameId }, game);
     });
   }
-
 
   getCurrentGameStatus(
     leagueId: number,


### PR DESCRIPTION
- 스케줄링 서비스의 경기 종료 및 취소 상태 처리 시 onComplete 콜백 쓰지 않고 바로 로직 처리하는 방식으로 변경

## 🤷‍♂️ Description

- 크론잡 onComplete 콜백 쓰지 않고 분기 후 후속 로직 처리로 변경